### PR TITLE
feat: add `blend` subcommand

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -1,0 +1,48 @@
+use crate::{Color, RGBA};
+
+/// Blend modes that determine how partially transparent source and backdrop colors
+/// interact when they overlap. For more information on color blending, see
+/// [here](https://www.w3.org/TR/compositing/#blending) and
+/// [here](https://en.wikipedia.org/wiki/Blend_modes).
+pub trait BlendMode {
+    fn blend_channel(backdrop: u8, source: u8) -> u8;
+
+    fn blend(backdrop: &RGBA<u8>, source: &RGBA<u8>) -> Color {
+        let r = Self::blend_channel(backdrop.r, source.r);
+        let g = Self::blend_channel(backdrop.g, source.g);
+        let b = Self::blend_channel(backdrop.b, source.b);
+        let a = (backdrop.alpha + source.alpha) / 2.0;
+
+        Color::from_rgba(r, g, b, a)
+    }
+}
+
+pub struct Multiply;
+pub struct Screen;
+pub struct Overlay;
+
+impl BlendMode for Multiply {
+    fn blend_channel(backdrop: u8, source: u8) -> u8 {
+        ((backdrop as f64 * source as f64) / 255.0).floor() as u8
+    }
+}
+
+impl BlendMode for Screen {
+    fn blend_channel(backdrop: u8, source: u8) -> u8 {
+        let backdrop = backdrop as f64 / 255.0;
+        let source = source as f64 / 255.0;
+        ((1.0 - (1.0 - backdrop) * (1.0 - source)) * 255.0) as u8
+    }
+}
+
+impl BlendMode for Overlay {
+    fn blend_channel(backdrop: u8, source: u8) -> u8 {
+        let backdrop = backdrop as f64 / 255.0;
+        let source = source as f64 / 255.0;
+        if backdrop < 0.5 {
+            ((2.0 * backdrop * source) * 255.0) as u8
+        } else {
+            ((1.0 - 2.0 * (1.0 - backdrop) * (1.0 - source)) * 255.0) as u8
+        }
+    }
+}

--- a/src/cli/blend.rs
+++ b/src/cli/blend.rs
@@ -1,0 +1,11 @@
+use pastel::blend::*;
+use pastel::Color;
+
+pub fn get_blending_function(blend_mode: &str) -> Box<dyn Fn(&Color, &Color) -> Color> {
+    match blend_mode.to_lowercase().as_ref() {
+        "multiply" => Box::new(|b: &Color, s: &Color| b.blend::<Multiply>(s)),
+        "screen" => Box::new(|b: &Color, s: &Color| b.blend::<Screen>(s)),
+        "overlay" => Box::new(|b: &Color, s: &Color| b.blend::<Overlay>(s)),
+        _ => unreachable!("Unknown blend mode"),
+    }
+}

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -330,6 +330,32 @@ pub fn build_cli() -> App<'static, 'static> {
                 .arg(color_arg.clone()),
         )
         .subcommand(
+            SubCommand::with_name("blend")
+                .about("Blend two colors using the given blend mode")
+                .long_about(
+                    "Create new colors by blending two colors using the given blend mode.\n\n\
+                     Example:\n  \
+                       pastel blend --blend_mode=multiply red blue")
+                .arg(
+                    Arg::with_name("blend_mode")
+                        .long("blend_mode")
+                        .short("b")
+                        .value_name("name")
+                        .help("The blend mode to use")
+                        .possible_values(&["multiply", "screen", "overlay"])
+                        .case_insensitive(true)
+                        .default_value("multiply")
+                        .required(true)
+                )
+                .arg(
+                    Arg::with_name("base")
+                        .value_name("backdrop")
+                        .help("The backdrop color on which the other color will be blended.")
+                        .required(true),
+                )
+                .arg(color_arg.clone().value_name("source").multiple(false)),
+        )
+        .subcommand(
             SubCommand::with_name("colorblind")
                 .about("Simulate a color under a certain colorblindness profile")
                 .long_about(

--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -1,5 +1,7 @@
+use crate::blend::get_blending_function;
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
+use crate::output::Blend;
 
 use pastel::ColorblindnessType;
 use pastel::Fraction;
@@ -75,6 +77,25 @@ color_command!(MixCommand, config, matches, color, {
     let mix = get_mixing_function(matches.value_of("colorspace").expect("required argument"));
 
     mix(&base, color, fraction)
+});
+
+color_command!(BlendCommand, config, matches, color, {
+    let mut print_spectrum = PrintSpectrum::Yes;
+
+    let base = ColorArgIterator::from_color_arg(
+        config,
+        matches.value_of("base").expect("required argument"),
+        &mut print_spectrum,
+    )?;
+
+    let blend = get_blending_function(matches.value_of("blend_mode").expect("required argument"));
+
+    // FIXME: maybe get rid of clones?
+    Blend {
+        backdrop: base.clone(),
+        source: color.clone(),
+        output: blend(&base, color),
+    }
 });
 
 color_command!(ColorblindCommand, config, matches, color, {

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -64,6 +64,7 @@ impl Command {
             "paint" => Command::Generic(Box::new(PaintCommand)),
             "format" => Command::WithColor(Box::new(FormatCommand)),
             "colorcheck" => Command::Generic(Box::new(ColorCheckCommand)),
+            "blend" => Command::WithColor(Box::new(color_commands::BlendCommand)),
             _ => unreachable!("Unknown subcommand"),
         }
     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 
 use atty::Stream;
 
+mod blend;
 mod cli;
 mod colorpicker;
 mod colorpicker_tools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ansi;
+pub mod blend;
 pub mod colorspace;
 pub mod delta_e;
 pub mod distinct;
@@ -10,6 +11,7 @@ mod types;
 
 use std::fmt;
 
+use blend::BlendMode;
 use colorspace::ColorSpace;
 pub use helper::Fraction;
 use helper::{clamp, interpolate, interpolate_angle, mod_positive};
@@ -619,6 +621,17 @@ impl Color {
         let b = composite_channel(source.b, source.alpha, backdrop.b, backdrop.alpha, a);
 
         Color::from_rgba(r, g, b, a)
+    }
+
+    /// Blend two colors, using the first as the backdrop and the second as the source.
+    /// The result is modulated by the backdrop alpha. A fully opaque backdrop will use
+    /// the blending function exclusively, while a partially or fully transparent
+    /// backdrop causes the result to be a weighted average between the source color
+    /// and the blended color.
+    pub fn blend<B: BlendMode>(&self, source: &Color) -> Color {
+        let backdrop = self.to_rgba();
+        let source = source.to_rgba();
+        B::blend(&backdrop, &source)
     }
 }
 


### PR DESCRIPTION
This PR is a work in progress, and builds on the changes in #162 (I _think_ that `Color::composite` may be reusable for blend compositing?).

Closes #60.

## TODO

- [ ] add tests
- [ ] properly consider alpha when blending